### PR TITLE
Update Freddy to use latest Hare

### DIFF
--- a/lib/freddy/notifications/listener.ex
+++ b/lib/freddy/notifications/listener.ex
@@ -58,5 +58,5 @@ defmodule Freddy.Notifications.Listener do
     Freddy.Consumer.start_link(mod, conn, config, initial, opts)
   end
 
-  defdelegate stop(consumer, reason \\ :normal), to: GenServer
+  defdelegate stop(consumer, reason \\ :normal), to: Freddy.Consumer
 end

--- a/lib/freddy/publisher.ex
+++ b/lib/freddy/publisher.ex
@@ -180,15 +180,11 @@ defmodule Freddy.Publisher do
     Hare.Publisher.start_link(__MODULE__, conn, config, {mod, initial}, opts)
   end
 
+  defdelegate publish(publisher, payload, routing_key \\ "", opts \\ []), to: Hare.Publisher
+  defdelegate call(publisher, message),           to: Hare.Publisher
+  defdelegate call(publisher, message, timeout),  to: Hare.Publisher
+  defdelegate cast(publisher, message),           to: Hare.Publisher
   defdelegate stop(publisher, reason \\ :normal), to: GenServer
-
-  @doc """
-  Publishes a message to an exchange through the `Freddy.Publisher` process.
-  """
-  @spec publish(GenServer.server, payload, routing_key, opts) :: :ok
-  def publish(publisher, payload, routing_key \\ "", opts \\ []) do
-    Hare.Actor.cast(publisher, {:"$hare_publication", payload, routing_key, opts})
-  end
 
   # Hare.Publisher callbacks
 

--- a/mix.exs
+++ b/mix.exs
@@ -36,8 +36,8 @@ defmodule Freddy.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:hare, git: "https://github.com/take-five/hare"},
-      {:amqp, "~> 0.2.0"},
+      {:hare, "~> 0.2.0", hex: :salemove_hare},
+      {:amqp, "~> 0.2.2"},
       {:poison, ">= 2.0.0"},
 
       {:mock, "~> 0.2.0", only: :test},

--- a/mix.lock
+++ b/mix.lock
@@ -1,9 +1,9 @@
-%{"amqp": {:hex, :amqp, "0.2.1", "bba2084129de2bdd0189d6deae6fb1654500e4c9b8be9909bf1b07778d54a58a", [:mix], [{:amqp_client, "~> 3.6.8", [hex: :amqp_client, repo: "hexpm", optional: false]}, {:rabbit_common, "~> 3.6.8", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm"},
-  "amqp_client": {:hex, :amqp_client, "3.6.9", "076d7c68abc670d1bb44bbc357e4fba991a3ab53ce6160ec43576c653849a643", [:make, :rebar3], [{:rabbit_common, "3.6.9", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm"},
+%{"amqp": {:hex, :amqp, "0.2.2", "eeb9d832c5440585699ae89f48c38f662a2d44f48e694dfe9ba15824b53da1f9", [:mix], [{:amqp_client, "~> 3.6.8", [hex: :amqp_client, repo: "hexpm", optional: false]}, {:rabbit_common, "~> 3.6.8", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm"},
+  "amqp_client": {:hex, :amqp_client, "3.6.10", "f26fbacca4e71f58eba1a57746e5f10598550aa46e89bc67060da6ad1a6d95d5", [:make, :rebar3], [{:rabbit_common, "3.6.10", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm"},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.0", "5bc543f9c28ecd51b99cc1a685a3c2a1a93216990347f259406a910cf048d1d7", [:mix], [], "hexpm"},
-  "hare": {:git, "https://github.com/take-five/hare", "945c1e167f4523e907fddfc57d1e86f2893a312d", []},
+  "hare": {:hex, :salemove_hare, "0.2.0", "6dfeb94f93e515e8e012069d475733aeabe63612ca6e0262da16e14313081661", [:mix], [{:amqp, "~> 0.2.2", [hex: :amqp, repo: "hexpm", optional: true]}, {:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}], "hexpm"},
   "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:make, :rebar], [], "hexpm"},
   "mock": {:hex, :mock, "0.2.1", "bfdba786903e77f9c18772dee472d020ceb8ef000783e737725a4c8f54ad28ec", [:mix], [{:meck, "~> 0.8.2", [hex: :meck, repo: "hexpm", optional: false]}], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
-  "rabbit_common": {:hex, :rabbit_common, "3.6.9", "d54e1bc366f5f553a75055dfc6c93f0025efee0322f98bdf8597aff8482b996d", [:make, :rebar3], [], "hexpm"}}
+  "rabbit_common": {:hex, :rabbit_common, "3.6.10", "2217845381350258c5714c22905ec197af0c4dd38eb3b6a5ddbf55c5bd93f127", [:make, :rebar3], [], "hexpm"}}

--- a/test/freddy/consumer_test.exs
+++ b/test/freddy/consumer_test.exs
@@ -136,20 +136,6 @@ defmodule Freddy.ConsumerTest do
       tear_down(consumer)
     end
 
-    test "consumer stops after receives cancel message", %{conn: conn, history: history} do
-      consumer = start_consumer(conn)
-      Process.unlink(consumer)
-
-      assert :ok == Freddy.Consumer.cancel(consumer)
-      assert {:cancel, [_chan, tag, []], :ok} = Adapter.Backdoor.last_event(history)
-
-      send(consumer, {:cancel_ok, %{consumer_tag: tag}})
-      assert_receive {:terminated, {:shutdown, :cancelled}}
-
-      Process.sleep(20)
-      refute Process.alive?(consumer)
-    end
-
     defp start_consumer(conn) do
       {:ok, consumer} = TestConsumer.start_link(conn, self())
       send(consumer, {:consume_ok, %{}})

--- a/test/freddy/rpc/client_test.exs
+++ b/test/freddy/rpc/client_test.exs
@@ -35,6 +35,9 @@ defmodule Freddy.RPC.ClientTest do
             {:consume,
               [channel, resp_queue_name, ^rpc_client, [no_ack: true]],
               {:ok, _consumer_tag}},
+            {:register_return_handler,
+              [channel, ^rpc_client],
+              :ok},
             {:publish,
               [channel, "" = _exchange, ^expected_payload, "TestQueue", [
                 mandatory: true,
@@ -44,7 +47,7 @@ defmodule Freddy.RPC.ClientTest do
                 reply_to: resp_queue_name,
                 correlation_id: correlation_id
               ]],
-              :ok}] = Adapter.Backdoor.last_events(history, 5)
+              :ok}] = Adapter.Backdoor.last_events(history, 6)
 
     response_payload = ~s[{"success":true,"output":42}]
 


### PR DESCRIPTION
Changes in Hare include:
* Support for unroutable messages in RPC.Client
* Improved reconnection mechanism

Also `Freddy.Consumer.cancel/1` is removed. Automatic graceful shutdown is to be implemented later.