### PR TITLE
Fix bug in `Freddy.RPC.Client.on_timeout/2` callback

### DIFF
--- a/lib/freddy/notifications/broadcaster.ex
+++ b/lib/freddy/notifications/broadcaster.ex
@@ -37,8 +37,6 @@ defmodule Freddy.Notifications.Broadcaster do
     Freddy.Publisher.start_link(mod, conn, [exchange: @exchange_config], initial, opts)
   end
 
-  defdelegate stop(broadcaster, reason \\ :normal), to: GenServer
-
   @doc """
   Publish message with the given `routing_key` and `payload` to "freddy-topic" exchange.
   The message will be encoded to JSON before publication.
@@ -53,4 +51,11 @@ defmodule Freddy.Notifications.Broadcaster do
   def broadcast(broadcaster, routing_key, payload, opts \\ []) do
     Freddy.Publisher.publish(broadcaster, payload, routing_key, opts)
   end
+
+  defdelegate call(consumer, message, timeout \\ 5000), to: Freddy.Publisher
+  defdelegate cast(consumer, message), to: Freddy.Publisher
+  defdelegate stop(consumer, reason \\ :normal), to: Freddy.Publisher
+  defdelegate ack(meta, opts \\ []), to: Freddy.Publisher
+  defdelegate nack(meta, opts \\ []), to: Freddy.Publisher
+  defdelegate reject(meta, opts \\ []), to: Freddy.Publisher
 end

--- a/lib/freddy/notifications/listener.ex
+++ b/lib/freddy/notifications/listener.ex
@@ -58,5 +58,10 @@ defmodule Freddy.Notifications.Listener do
     Freddy.Consumer.start_link(mod, conn, config, initial, opts)
   end
 
+  defdelegate call(consumer, message, timeout \\ 5000), to: Freddy.Consumer
+  defdelegate cast(consumer, message), to: Freddy.Consumer
   defdelegate stop(consumer, reason \\ :normal), to: Freddy.Consumer
+  defdelegate ack(meta, opts \\ []), to: Freddy.Consumer
+  defdelegate nack(meta, opts \\ []), to: Freddy.Consumer
+  defdelegate reject(meta, opts \\ []), to: Freddy.Consumer
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Freddy.Mixfile do
 
   def project do
     [app: :freddy,
-     version: "0.9.0",
+     version: "0.9.1",
      elixir: "~> 1.4",
      elixirc_paths: elixirc_paths(Mix.env),
      build_embedded: Mix.env == :prod,


### PR DESCRIPTION
`Freddy.RPC.Client` passed arguments to `on_timeout/2` callback
in wrong order which put process into bad state.

To test it I had to add `handle_call` callback to `Freddy.RPC.Client`.
Then I decided to add GenServer-like callbacks to all abstractions.