### PR TITLE
Don't bind RPC.Client to fixed routing key

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The package can be installed as:
   1. Add `freddy` to your list of dependencies in `mix.exs`:
   ```elixir
   def deps do
-    [{:freddy, "~> 0.9.2"}]
+    [{:freddy, "~> 0.10.0"}]
   end
   ```
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The package can be installed as:
   1. Add `freddy` to your list of dependencies in `mix.exs`:
   ```elixir
   def deps do
-    [{:freddy, github: "salemove/ex_freddy"}]
+    [{:freddy, "~> 0.9.2"}]
   end
   ```
 
@@ -33,14 +33,14 @@ The package can be installed as:
   defmodule AMQPService do
     use Freddy.RPC.Client
     
-    @config [routing_key: "amqp-service"]
+    @routing_key "amqp-service"
     
     def start_link(conn, initial \\ nil, opts \\ []) do
-      Freddy.RPC.Client.start_link(__MODULE__, conn, @config, initial, opts)
+      Freddy.RPC.Client.start_link(__MODULE__, conn, [], initial, opts)
     end
     
-    def ping(client) do
-      Freddy.RPC.Client.request(client, %{type: "ping"})
+    def ping(client \\ __MODULE__) do
+      Freddy.RPC.Client.request(client, @routing_key, %{type: "ping"})
     end
   end
   ```
@@ -67,7 +67,7 @@ The package can be installed as:
     
   4. You can now use your client:
   ```elixir
-  case AMQPService.ping(AMQPService) do
+  case AMQPService.ping() do
     {:ok, resp} -> 
       IO.puts "Response: #{inspect response}"
       

--- a/lib/freddy/rpc/request.ex
+++ b/lib/freddy/rpc/request.ex
@@ -1,0 +1,79 @@
+defmodule Freddy.RPC.Request do
+  @moduledoc """
+  RPC Request data structure. Applications may modify this data structure.
+  For example, one might want to add some specific publication option to
+  every request, or change routing key, based on request payload, or just
+  add some application-specific meta-information.
+  """
+
+  alias __MODULE__
+
+  @type t :: %__MODULE__{
+              id: id,
+              routing_key: routing_key,
+              payload: payload,
+              start_time: time,
+              stop_time: time | nil,
+              options: options,
+              meta: map}
+
+  @typedoc "Request identifier. Used only internally, can be anything"
+  @type id :: term
+
+  @typedoc "Request routing key"
+  @type routing_key :: binary
+
+  @typedoc "Request options"
+  @type options :: Keyword.t
+
+  @typedoc "Request payload"
+  @type payload :: term
+
+  @typedoc "Request meta information. Application can put their specific data here"
+  @type meta :: map
+
+  @type time :: integer
+
+  defstruct id: nil,
+            routing_key: "",
+            payload: nil,
+            start_time: nil,
+            stop_time: nil,
+            options: [],
+            meta: %{}
+
+  @spec start(id, payload, routing_key, options) :: t
+  def start(id, payload, routing_key, options) do
+    %Request{id:          id,
+             routing_key: routing_key,
+             payload:     payload,
+             options:     options,
+             start_time:  now()}
+  end
+
+  @spec finish(t) :: t
+  def finish(%Request{} = req),
+    do: %{req | stop_time: now()}
+
+  @spec duration(t, granularity :: System.time_unit) :: integer
+  def duration(%Request{start_time: t1, stop_time: t2} = _req, granularity \\ :milliseconds) when is_integer(t2),
+    do: System.convert_time_unit(t2 - t1, :native, granularity)
+
+  @spec update_routing_key(t, routing_key) :: t
+  def update_routing_key(%Request{} = req, new_routing_key),
+    do: %{req | routing_key: new_routing_key}
+
+  @spec update_payload(t, payload) :: t
+  def update_payload(%Request{} = req, new_payload),
+    do: %{req | payload: new_payload}
+
+  @spec put_option(t, option :: atom, value :: term) :: t
+  def put_option(%Request{options: options} = req, option, value),
+    do: %{req | options: Keyword.put(options, option, value)}
+
+  @spec put_meta(t, key :: term, value :: term) :: t
+  def put_meta(%Request{meta: meta} = req, key, value),
+    do: %{req | meta: Map.put(meta, key, value)}
+
+  defp now(), do: System.monotonic_time()
+end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Freddy.Mixfile do
 
   def project do
     [app: :freddy,
-     version: "0.9.2",
+     version: "0.10.0",
      elixir: "~> 1.4",
      elixirc_paths: elixirc_paths(Mix.env),
      build_embedded: Mix.env == :prod,

--- a/test/freddy/rpc/client_test.exs
+++ b/test/freddy/rpc/client_test.exs
@@ -6,30 +6,39 @@ defmodule Freddy.RPC.ClientTest do
   defmodule TestClient do
     use Client
 
-    def start_link(conn, config, initial, opts \\ []) do
-      Client.start_link(__MODULE__, conn, config, initial, opts)
+    def start_link(conn, config, pid \\ self(), opts \\ []) do
+      Client.start_link(__MODULE__, conn, config, pid, opts)
+    end
+
+    def handle_ready(meta, pid) do
+      send(pid, {:ready, meta})
+      {:noreply, pid}
+    end
+
+    def before_request(%{options: opts} = request, pid) do
+      send(pid, {:before_request, request})
+
+      case opts[:hook] do
+        {:modify, fields} -> {:ok, Map.merge(request, fields), pid}
+        {:stop, reason, reply} -> {:stop, reason, reply, pid}
+        {:reply, reply} -> {:reply, reply, pid}
+        nil -> {:ok, pid}
+      end
     end
 
     def get_state(client) do
       Client.call(client, :get_state)
     end
 
-    def handle_call(:get_state, _from, state) do
-      {:reply, state, state}
+    def handle_call(:get_state, _from, pid) do
+      {:reply, pid, pid}
     end
   end
 
-  test "sends request to specified queue", %{conn: conn, history: history} do
-    queue_name = "TestQueue"
-    rpc_client = start_client(conn, [routing_key: queue_name])
-
-    request = Task.async fn ->
-      Freddy.RPC.Client.request(rpc_client, %{type: "action", key: "value"})
-    end
-
-    assert nil == Task.yield(request, 100)
-
-    expected_payload = ~s[{"type":"action","key":"value"}]
+  test "starts consumption and sets up return handler on start", %{conn: conn, history: history} do
+    rpc_client = start_client(conn, [])
+    assert_receive {:ready, %{resp_queue: resp_queue}}
+    %{consumer_tag: consumer_tag, name: resp_queue_name} = resp_queue
 
     assert [{:open_channel,
               [_conn],
@@ -39,51 +48,147 @@ defmodule Freddy.RPC.ClientTest do
               _ref},
             {:declare_server_named_queue,
               [channel, [auto_delete: true, exclusive: true]],
-              {:ok, resp_queue_name, _queue_info}},
+              {:ok, ^resp_queue_name, _queue_info}},
             {:consume,
-              [channel, resp_queue_name, ^rpc_client, [no_ack: true]],
-              {:ok, _consumer_tag}},
+              [channel, ^resp_queue_name, ^rpc_client, [no_ack: true]],
+              {:ok, ^consumer_tag}},
             {:register_return_handler,
               [channel, ^rpc_client],
-              :ok},
-            {:publish,
-              [channel, "" = _exchange, ^expected_payload, "TestQueue", [
-                mandatory: true,
-                content_type: "application/json",
-                expiration: "3000",
-                type: "request",
-                reply_to: resp_queue_name,
-                correlation_id: correlation_id
-              ]],
-              :ok}] = Adapter.Backdoor.last_events(history, 6)
+              :ok}] = Adapter.Backdoor.last_events(history, 5)
+  end
 
-    response_payload = ~s[{"success":true,"output":42}]
+  describe "before_request/3" do
+    test "sends original payload and original routing key on {:ok, state}", %{conn: conn, history: history} do
+      rpc_client = start_client(conn, [])
 
-    send(rpc_client, {:deliver, response_payload, %{correlation_id: correlation_id}})
+      routing_key = "TestQueue"
+      payload = %{type: "action", key: "value"}
+      encoded_payload = Poison.encode!(payload)
 
-    assert {:ok, 42} = Task.await(request)
+      request = Task.async fn ->
+        Freddy.RPC.Client.request(rpc_client, routing_key, payload)
+      end
+
+      assert_receive {:before_request, %{payload: ^payload, routing_key: ^routing_key, options: _opts}}
+
+      assert nil == Task.yield(request, 100)
+
+      assert {:publish,
+              [_chan, "" = _exchange, ^encoded_payload, ^routing_key, options],
+              :ok} = Adapter.Backdoor.last_event(history)
+
+      %{correlation_id: correlation_id} = assert_options_injected(options)
+      respond_to(rpc_client, %{success: true, output: 42}, %{correlation_id: correlation_id})
+
+      assert {:ok, 42} = Task.await(request)
+    end
+
+    test "sends modified routing key, payload and options on {:ok, request, state}", %{conn: conn, history: history} do
+      rpc_client = start_client(conn, [])
+
+      original_routing_key = "TestQueue"
+      modified_routing_key = "TestQueue2"
+
+      original_payload = %{type: "action", key: "value"}
+      modified_payload = %{type: "another_action", key: "new_value"}
+      encoded_payload = Poison.encode!(modified_payload)
+
+      modified_options = [app_id: "testapp2"]
+
+      options = [app_id: "testapp", hook: {:modify, %{
+        payload: modified_payload,
+        routing_key: modified_routing_key,
+        options: modified_options
+      }}]
+
+      request = Task.async fn ->
+        Freddy.RPC.Client.request(rpc_client, original_routing_key, original_payload, options)
+      end
+
+      assert_receive {:before_request,
+                       %{payload: ^original_payload, routing_key: ^original_routing_key, options: given_options}}
+
+      assert given_options[:app_id] == "testapp"
+      assert Keyword.has_key?(given_options, :correlation_id)
+
+      assert nil == Task.yield(request, 100)
+
+      assert {:publish,
+              [_chan, "" = _exchange, ^encoded_payload, ^modified_routing_key, published_options],
+              :ok} = Adapter.Backdoor.last_event(history)
+
+      %{correlation_id: correlation_id} = assert_options_injected(published_options)
+      respond_to(rpc_client, %{success: true, output: 42}, %{correlation_id: correlation_id})
+
+      assert {:ok, 42} = Task.await(request)
+    end
+
+    test "returns reply on {:reply, reply, state}", %{conn: conn} do
+      rpc_client = start_client(conn, [])
+      assert :response = Freddy.RPC.Client.request(rpc_client, "key", "payload", hook: {:reply, :response})
+    end
+
+    test "stops the process on {:stop, reason, reply, state}", %{conn: conn} do
+      rpc_client = start_client(conn, [])
+
+      ref = Process.monitor(rpc_client)
+
+      assert :response = Freddy.RPC.Client.request(rpc_client, "key", "payload", hook: {:stop, :normal, :response})
+      assert_receive {:DOWN, ^ref, :process, ^rpc_client, :normal}
+    end
   end
 
   test "returns `{:error, :timeout}` on timeouts", %{conn: conn} do
-    rpc_client = start_client(conn, [routing_key: "TestQueue", timeout: 1], :given_state)
-    assert :given_state == TestClient.get_state(rpc_client)
+    rpc_client = start_client(conn, [timeout: 1])
+    routing_key = "TestQueue"
+    initial_state = TestClient.get_state(rpc_client)
 
     request = Task.async fn ->
-      Freddy.RPC.Client.request(rpc_client, %{})
+      Freddy.RPC.Client.request(rpc_client, routing_key, %{})
     end
 
     assert {:ok, result} = Task.yield(request, 100)
     assert {:error, :timeout} == result
 
-    assert :given_state == TestClient.get_state(rpc_client)
+    assert ^initial_state = TestClient.get_state(rpc_client)
   end
 
-  defp start_client(conn, config, initial \\ nil) do
-    {:ok, rpc_client} = TestClient.start_link(conn, config, initial)
+  test "returns `{:error, :no_route}` on return", %{conn: conn} do
+    rpc_client = start_client(conn, [])
+    routing_key = "TestQueue"
+    initial_state = TestClient.get_state(rpc_client)
+
+    request = Task.async fn ->
+      Freddy.RPC.Client.request(rpc_client, routing_key, %{})
+    end
+    assert_receive {:before_request, %{options: [correlation_id: correlation_id]}}
+
+    send(rpc_client, {:return, "", %{correlation_id: correlation_id}})
+    assert {:error, :no_route} = Task.await(request)
+
+    assert ^initial_state = TestClient.get_state(rpc_client)
+  end
+
+  defp start_client(conn, config) do
+    {:ok, rpc_client} = TestClient.start_link(conn, config, self())
 
     # Emulate RabbitMQ confirmation
     send(rpc_client, {:consume_ok, %{}})
 
     rpc_client
+  end
+
+  defp assert_options_injected(options) do
+    assert options[:mandatory]
+    assert options[:content_type] == "application/json"
+    assert Keyword.has_key?(options, :expiration)
+    assert Keyword.has_key?(options, :reply_to)
+    assert Keyword.has_key?(options, :correlation_id)
+
+    Map.new(options)
+  end
+
+  defp respond_to(rpc_client, payload, meta) do
+    send(rpc_client, {:deliver, Poison.encode!(payload), meta})
   end
 end


### PR DESCRIPTION
After using RPC.Client in real project, I've found out that
binding RPC Client to a single routing key leads to bad design. E.g.
we have to spawn several similar processes to communicate with
several services whilst 1 process could do the same.

This commit allows to have one RPC.Client process for multiple services.

For example:
```
defmodule MyApp.RPC.Client do
  use Freddy.RPC.Client

  def start_link(conn), do: Freddy.RPC.Client.start_link(__MODULE__, conn, [], nil, name: Client)
end

defmodule MyApp.SitesService do
  def get_sites(), do: MyApp.RPC.Client.request(Client, "SitesQueue", %{type: "get_sites"})
end

defmodule MyApp.UsersService do
  def get_users(), do: MyApp.RPC.Client.request(Client, "SitesQueue", %{type: "get_useres"})
end
```

One RPC.Client process can handle multiple requests at the same time.

Also, interface of `before_request`, `on_response` and `on_timeout` callbacks
has been changed. Now these callbacks accept `Freddy.RPC.Request` data structure
as a first argument. This structure holds all necessary request information: payload,
routing key, options etc. In addition, callback `on_return` has been added which
mirrors `on_return` callbacks from `hare` and follows the same semantics as the
callbacks, mentioned above.