### PR TITLE
Create Sandbox adapter to use in unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ calls to a client. This way you can test how your code communicates with RPC cli
 [Mox documentation](https://hexdocs.pm/mox/Mox.html) for more information about mocks and explicit contracts.
 
 If you need to test RPC client itself, you can hook into request lifecycle and use `before_request/2` callback
-to return required responses. Please note, that real connection is required for such tests.
+to return required responses. It is recommended to use fake connection in test environment:
 
 ```elixir
 defmodule MockClient do
@@ -324,7 +324,8 @@ end
 And use it in tests:
 ```elixir
 test "sends an RPC request" do
-  {:ok, client} = MockClient.start_link()
+  {:ok, conn} = Freddy.Connection.start_link(adapter: :sandbox)
+  {:ok, client} = MockClient.start_link(conn)
   MyLib.call(client: client)
 
   assert [%{routing_key: "server"}] = MockClient.flush(client)

--- a/lib/freddy/adapter.ex
+++ b/lib/freddy/adapter.ex
@@ -142,6 +142,10 @@ defmodule Freddy.Adapter do
     Freddy.Adapter.AMQP
   end
 
+  def get(:sandbox) do
+    Freddy.Adapter.Sandbox
+  end
+
   def get(adapter) do
     adapter
   end

--- a/lib/freddy/adapter/sandbox.ex
+++ b/lib/freddy/adapter/sandbox.ex
@@ -1,0 +1,149 @@
+defmodule Freddy.Adapter.Sandbox do
+  @moduledoc """
+  Special no-op Freddy adapter designed to be used in automated
+  tests instead of real AMQP connection.
+
+  ## Example
+
+      iex> alias #{__MODULE__}
+      iex> alias Freddy.Connection
+      iex> alias Freddy.Core.Exchange
+      iex> {:ok, conn} = Connection.start_link(adapter: :sandbox)
+      iex> {:ok, channel} = Connection.open_channel(conn)
+      iex> :ok = Exchange.declare(%Exchange{name: "test"}, channel)
+      iex> Sandbox.history(conn)
+      [{:open_channel, [conn]}, {:declare_exchange, [channel, "test", :direct, []]}]
+  """
+
+  @behaviour Freddy.Adapter
+
+  alias Freddy.Adapter.Sandbox.{Connection, Channel}
+
+  import Channel, only: [register: 3]
+
+  @doc """
+  Get history of events from connection. Events can be filtered by type,
+  for example, if one wants to get only history of messages, published
+  over given connection, he should call `history(connection, :publish)`.
+  """
+  def history(connection, events \\ :all) do
+    Connection.history(connection, events)
+  end
+
+  @impl true
+  defdelegate open_connection(opts), to: Connection, as: :open
+
+  @impl true
+  def link_connection(connection) do
+    Connection.register(connection, :link_connection, [connection])
+    Connection.link(connection)
+    :ok
+  end
+
+  @impl true
+  def close_connection(connection) do
+    Connection.register(connection, :close_connection, [connection])
+    Connection.close(connection)
+  end
+
+  @impl true
+  def open_channel(connection) do
+    Connection.register(connection, :open_channel, [connection])
+    Channel.open(connection)
+  end
+
+  @impl true
+  def monitor_channel(channel) do
+    register(channel, :monitor_channel, [channel])
+    Channel.monitor(channel)
+  end
+
+  @impl true
+  def close_channel(channel) do
+    register(channel, :close_channel, [channel])
+    Channel.close(channel)
+  end
+
+  @impl true
+  def register_return_handler(channel, pid) do
+    register(channel, :register_return_handler, [channel, pid])
+    :ok
+  end
+
+  @impl true
+  def declare_exchange(channel, name, type, opts) do
+    register(channel, :declare_exchange, [channel, name, type, opts])
+    :ok
+  end
+
+  @impl true
+  def bind_exchange(channel, dest, source, opts) do
+    register(channel, :bind_exchange, [channel, dest, source, opts])
+    :ok
+  end
+
+  @impl true
+  def declare_queue(channel, name, opts)
+
+  def declare_queue(channel, "", opts) do
+    generated_name = "generated_name_#{:rand.uniform(10000)}"
+    register(channel, :declare_queue, [channel, "", opts])
+    {:ok, generated_name}
+  end
+
+  def declare_queue(channel, name, opts) do
+    register(channel, :declare_queue, [channel, name, opts])
+    {:ok, name}
+  end
+
+  @impl true
+  def bind_queue(channel, queue, exchange, options) do
+    Channel.register(channel, :bind_queue, [channel, queue, exchange, options])
+    :ok
+  end
+
+  @impl true
+  def publish(channel, exchange, routing_key, payload, opts) do
+    register(channel, :publish, [channel, exchange, routing_key, payload, opts])
+  end
+
+  @impl true
+  def consume(channel, queue, consumer, options) do
+    consumer_tag = "consumer_#{:rand.uniform(10000)}"
+    register(channel, :consume, [channel, queue, consumer, consumer_tag, options])
+    {:ok, consumer_tag}
+  end
+
+  @impl true
+  def qos(channel, opts) do
+    register(channel, :qos, [channel, opts])
+    :ok
+  end
+
+  @impl true
+  def ack(channel, delivery_tag, opts) do
+    register(channel, :ack, [channel, delivery_tag, opts])
+  end
+
+  @impl true
+  def nack(channel, delivery_tag, opts) do
+    register(channel, :nack, [channel, delivery_tag, opts])
+  end
+
+  @impl true
+  def reject(channel, delivery_tag, opts) do
+    register(channel, :reject, [channel, delivery_tag, opts])
+  end
+
+  @impl true
+  def handle_message(message) do
+    case message do
+      {:consume_ok, _meta} -> message
+      {:deliver, _payload, _meta} -> message
+      {:cancel_ok, _meta} -> message
+      {:cancel, _meta} -> message
+      {:return, _payload, _meta} -> message
+      _ -> :unknown
+    end
+  end
+end

--- a/lib/freddy/adapter/sandbox/channel.ex
+++ b/lib/freddy/adapter/sandbox/channel.ex
@@ -1,0 +1,33 @@
+defmodule Freddy.Adapter.Sandbox.Channel do
+  @moduledoc false
+
+  use GenServer
+
+  alias Freddy.Adapter.Sandbox.Connection
+
+  def open(connection) do
+    GenServer.start_link(__MODULE__, connection)
+  end
+
+  def monitor(channel) do
+    Process.monitor(channel)
+  end
+
+  def close(channel) do
+    GenServer.stop(channel)
+  end
+
+  def register(channel, event, args) do
+    GenServer.call(channel, {:register, event, args})
+  end
+
+  @impl true
+  def init(connection) do
+    {:ok, connection}
+  end
+
+  @impl true
+  def handle_call({:register, event, args}, _from, connection) do
+    {:reply, Connection.register(connection, event, args), connection}
+  end
+end

--- a/lib/freddy/adapter/sandbox/connection.ex
+++ b/lib/freddy/adapter/sandbox/connection.ex
@@ -1,0 +1,49 @@
+defmodule Freddy.Adapter.Sandbox.Connection do
+  @moduledoc false
+
+  use GenServer
+
+  def open(_opts) do
+    GenServer.start_link(__MODULE__, nil)
+  end
+
+  def link(pid) do
+    Process.link(pid)
+  end
+
+  def close(pid) do
+    GenServer.stop(pid)
+  end
+
+  def register(connection, event, args) do
+    GenServer.call(connection, {:register, event, args})
+  end
+
+  def history(connection, type) do
+    GenServer.call(connection, {:history, type})
+  end
+
+  @impl true
+  def init(_) do
+    {:ok, []}
+  end
+
+  @impl true
+  def handle_call({:register, event, args}, _from, history) do
+    {:reply, :ok, [{event, args} | history]}
+  end
+
+  def handle_call({:history, :all}, _from, history) do
+    {:reply, Enum.reverse(history), history}
+  end
+
+  def handle_call({:history, type}, _from, history) do
+    matching_events =
+      Enum.reduce(history, [], fn
+        {^type, _} = event, acc -> [event | acc]
+        _, acc -> acc
+      end)
+
+    {:reply, matching_events, history}
+  end
+end

--- a/lib/freddy/core/bind.ex
+++ b/lib/freddy/core/bind.ex
@@ -28,7 +28,7 @@ defmodule Freddy.Core.Bind do
           arguments: Keyword.t()
         }
 
-  defstruct channel: nil, routing_key: "#", nowait: false, arguments: []
+  defstruct routing_key: "#", nowait: false, arguments: []
 
   @doc """
   Create binding configuration from keyword list or `Freddy.Core.Bind` structure.

--- a/mix.lock
+++ b/mix.lock
@@ -2,7 +2,7 @@
   "amqp": {:hex, :amqp, "0.3.1", "c22887ff851e57c8012a7b340a9a837ae997ee819079e447222100ef2a1a7735", [:mix], [{:amqp_client, "~> 3.6.14", [hex: :amqp_client, repo: "hexpm", optional: false]}, {:rabbit_common, "~> 3.6.14", [hex: :rabbit_common, repo: "hexpm", optional: false]}, {:recon, "~> 2.3.2", [hex: :recon, repo: "hexpm", optional: false]}], "hexpm"},
   "amqp_client": {:hex, :amqp_client, "3.6.15", "a171f78870adc9f6b7294a2974c30ea0817f0bbcee63acb0c469650452134608", [:make, :rebar3], [{:rabbit_common, "3.6.15", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm"},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
-  "dialyxir": {:hex, :dialyxir, "0.5.0", "5bc543f9c28ecd51b99cc1a685a3c2a1a93216990347f259406a910cf048d1d7", [:mix], [], "hexpm"},
+  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "jason": {:hex, :jason, "1.0.0", "0f7cfa9bdb23fed721ec05419bcee2b2c21a77e926bce0deda029b5adc716fe2", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},

--- a/test/freddy/adapter/sandbox_test.exs
+++ b/test/freddy/adapter/sandbox_test.exs
@@ -1,0 +1,77 @@
+defmodule Freddy.Adapter.SandboxTest do
+  use ExUnit.Case, async: true
+
+  import Freddy.Adapter.Sandbox
+
+  setup do
+    {:ok, conn} = open_connection([])
+    {:ok, chan} = open_channel(conn)
+    {:ok, conn: conn, chan: chan}
+  end
+
+  test "registers channel events in connection history", %{conn: conn, chan: chan} do
+    return_handler = self()
+    assert ref = monitor_channel(chan)
+    assert is_reference(ref)
+    assert :ok = register_return_handler(chan, return_handler)
+    assert :ok = qos(chan, prefetch_count: 10)
+    assert :ok = ack(chan, "tag1", [])
+    assert :ok = nack(chan, "tag2", requeue: false)
+    assert :ok = reject(chan, "tag3", requeue: false)
+    assert :ok = close_channel(chan)
+
+    assert [
+             {:open_channel, [^conn]},
+             {:monitor_channel, [^chan]},
+             {:register_return_handler, [^chan, ^return_handler]},
+             {:qos, [^chan, [prefetch_count: 10]]},
+             {:ack, [^chan, "tag1", []]},
+             {:nack, [^chan, "tag2", [requeue: false]]},
+             {:reject, [^chan, "tag3", [requeue: false]]},
+             {:close_channel, [^chan]}
+           ] = history(conn)
+  end
+
+  test "registers exchange events in connection history", %{conn: conn, chan: chan} do
+    assert :ok = declare_exchange(chan, "topic-exchange", :topic, [])
+    assert :ok = declare_exchange(chan, "fanout-exchange", :fanout, durable: true)
+    assert :ok = bind_exchange(chan, "fanout-exchange", "topic-exchange", routing_key: "#")
+    assert :ok = publish(chan, "topic-exchange", "key", "payload", durable: true)
+
+    assert [
+             {:open_channel, [^conn]},
+             {:declare_exchange, [^chan, "topic-exchange", :topic, []]},
+             {:declare_exchange, [^chan, "fanout-exchange", :fanout, [durable: true]]},
+             {:bind_exchange, [^chan, "fanout-exchange", "topic-exchange", [routing_key: "#"]]},
+             {:publish, [^chan, "topic-exchange", "key", "payload", [durable: true]]}
+           ] = history(conn)
+  end
+
+  test "registers queue events in connection history", %{conn: conn, chan: chan} do
+    assert {:ok, name} = declare_queue(chan, "", durable: true)
+    assert :ok = bind_queue(chan, name, "topic-exchange", routing_key: "#")
+
+    consumer = self()
+    assert {:ok, tag} = consume(chan, name, consumer, [])
+
+    assert [
+             {:open_channel, [^conn]},
+             {:declare_queue, [^chan, "", [durable: true]]},
+             {:bind_queue, [^chan, ^name, "topic-exchange", [routing_key: "#"]]},
+             {:consume, [^chan, ^name, ^consumer, ^tag, []]}
+           ] = history(conn)
+  end
+
+  test "returns event by type if specified", %{conn: conn, chan: chan} do
+    assert :ok = publish(chan, "exchange", "key1", "payload", [])
+    assert :ok = publish(chan, "exchange", "key2", "payload", [])
+    assert :ok = close_channel(chan)
+
+    assert [
+             {:publish, [^chan, "exchange", "key1", "payload", []]},
+             {:publish, [^chan, "exchange", "key2", "payload", []]}
+           ] = history(conn, :publish)
+
+    assert history(conn) != history(conn, :publish)
+  end
+end


### PR DESCRIPTION
The Sandbox adapter doesn't communicate with real RabbitMQ and
allows retrieving events history.