### PR TITLE
Handle connection timeouts

### DIFF
--- a/lib/freddy/adapter/amqp/connection.ex
+++ b/lib/freddy/adapter/amqp/connection.ex
@@ -1,8 +1,25 @@
 defmodule Freddy.Adapter.AMQP.Connection do
   @moduledoc false
 
-  def open(options) do
-    case AMQP.Connection.open(options) do
+  @default_options [
+    heartbeat: 10,
+    connection_timeout: 5000
+  ]
+
+  def open(options)
+
+  def open(options) when is_list(options) do
+    @default_options
+    |> Keyword.merge(options)
+    |> do_open()
+  end
+
+  def open(uri) when is_binary(uri) do
+    do_open(uri)
+  end
+
+  defp do_open(options_or_uri) do
+    case AMQP.Connection.open(options_or_uri) do
       {:ok, %{pid: pid}} -> {:ok, pid}
       {:error, _reason} = result -> result
     end

--- a/lib/freddy/connection.ex
+++ b/lib/freddy/connection.ex
@@ -25,8 +25,8 @@ defmodule Freddy.Connection do
     virtual_host: "The name of a virtual host in the broker (defaults to \"/\")",
     channel_max: "The channel_max handshake parameter (defaults to `0`)",
     frame_max: "The frame_max handshake parameter (defaults to `0`)",
-    heartbeat: "The hearbeat interval in seconds (defaults to `0` - turned off)",
-    connection_timeout: "The connection timeout in milliseconds (defaults to `infinity`)",
+    heartbeat: "The hearbeat interval in seconds (defaults to `10`)",
+    connection_timeout: "The connection timeout in milliseconds (defaults to `5000`)",
     ssl_options: "Enable SSL by setting the location to cert files (defaults to `none`)",
     client_properties:
       "A list of extra client properties to be sent to the server, defaults to `[]`",

--- a/lib/freddy/connection.ex
+++ b/lib/freddy/connection.ex
@@ -124,9 +124,9 @@ defmodule Freddy.Connection do
   @doc """
   Opens a new AMQP channel
   """
-  @spec open_channel(connection) :: {:ok, Channel.t()} | {:error, reason :: term}
-  def open_channel(connection) do
-    Connection.call(connection, :open_channel)
+  @spec open_channel(connection, timeout) :: {:ok, Channel.t()} | {:error, reason :: term}
+  def open_channel(connection, timeout \\ 5000) do
+    Connection.call(connection, :open_channel, timeout)
   end
 
   @doc """

--- a/test/freddy/core/actor_test.exs
+++ b/test/freddy/core/actor_test.exs
@@ -1,0 +1,73 @@
+defmodule Freddy.Core.ActorTest do
+  use ExUnit.Case, async: true
+
+  defmodule ConnectionSlowProxy do
+    # proxies calls to Freddy.Connection, but adds a delay before
+    # opening a channel first time
+
+    use GenServer
+
+    def start_link(initial_delay) do
+      GenServer.start_link(__MODULE__, initial_delay)
+    end
+
+    def init(initial_delay) do
+      {:ok, connection} = Freddy.Connection.start_link(adapter: :sandbox)
+      {:ok, %{connection: connection, delay: initial_delay}}
+    end
+
+    def handle_call(:open_channel, _from, %{connection: connection, delay: delay}) do
+      Process.sleep(delay)
+      {:reply, Freddy.Connection.open_channel(connection), %{connection: connection, delay: 0}}
+    end
+  end
+
+  defmodule TestActor do
+    @behaviour Freddy.Core.Actor
+
+    def start_link(connection) do
+      Freddy.Core.Actor.start_link(__MODULE__, connection, false)
+    end
+
+    def connected?(actor) do
+      GenServer.call(actor, :get)
+    end
+
+    def init(connected?) do
+      {:ok, connected?}
+    end
+
+    def handle_connected(_meta, _connected?) do
+      {:noreply, true}
+    end
+
+    def handle_disconnected(_reason, _connected?) do
+      {:noreply, false}
+    end
+
+    def handle_call(:get, _from, connected?) do
+      {:reply, connected?, connected?}
+    end
+
+    def handle_cast(_message, state) do
+      {:noreply, state}
+    end
+
+    def handle_info(_message, state) do
+      {:noreply, state}
+    end
+
+    def terminate(_reason, _state) do
+      :ok
+    end
+  end
+
+  test "retries if channel couldn't be opened" do
+    {:ok, conn} = ConnectionSlowProxy.start_link(5000)
+    {:ok, actor} = TestActor.start_link(conn)
+
+    refute TestActor.connected?(actor)
+    Process.sleep(5000)
+    assert TestActor.connected?(actor)
+  end
+end


### PR DESCRIPTION
This PR improves actors behaviour in situations when connection to RabbitMQ cannot be established quickly (currently actors would crash and restarted by supervisor in this case). Now actors should retry to open channel if previous attempt timed out or failed for other reason.

More info in commits.