### PR TITLE
Preparations for release 0.14.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,24 +11,22 @@ shared: &shared
 
     - restore_cache:
         keys:
-          - v1-mix-cache-{{ .Branch }}-{{ .Environment.ELIXIR_VERSION }}-{{ checksum "mix.lock" }}
+          - v1-mix-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "mix.lock" }}
     - restore_cache:
         keys:
-          - v1-build-cache-{{ .Branch }}-{{ .Environment.ELIXIR_VERSION }}
+          - v1-build-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
     - run: mix do deps.get, compile
     - save_cache:
-        key: v1-mix-cache-{{ .Branch }}-{{ .Environment.ELIXIR_VERSION }}-{{ checksum "mix.lock" }}
+        key: v1-mix-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "mix.lock" }}
         paths: "deps"
     - save_cache:
-        key: v1-build-cache-{{ .Branch }}-{{ .Environment.ELIXIR_VERSION }}
+        key: v1-build-cache-{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}
         paths: "_build"
 
     - run: mix test
 
 jobs:
   "elixir-1.5":
-    environment:
-      ELIXIR_VERSION: "1.5"
     docker:
       - image: circleci/elixir:1.5
         environment:
@@ -38,8 +36,6 @@ jobs:
     <<: *shared
 
   "elixir-1.6":
-    environment:
-      ELIXIR_VERSION: "1.6"
     docker:
       - image: circleci/elixir:1.6
         environment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,110 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [0.14.0] (In progress)
+
+### Added
+- `Freddy.RPC.Server` behaviour (#18)
+- Support for connection to multiple hosts (#19)
+- Support for exponential backoff intervals when re-establishing disrupted connection (#21)
+- This changelog
+
+### Changed
+- `Freddy.RPC.Client` doesn't require response to have `%{success: true, output: result}` structure (c4b8aa3)
+- Freddy now uses CircleCI to run tests (#20)
+- Default connection options changed to have `[heartbeat: 10, connection_timeout: 5000]` options (ca44419)
+
+### Deprecated
+- `Freddy.Notifications.Listener` behaviour will be removed in 1.0
+- `Freddy.Notifications.Broadcaster` behaviour will be removed in 1.0
+
+### Fixed
+- Fix crashing actors when connection couldn't be established in 5 seconds (ebc12c3)
+
+## [0.13.1] - 2018-06-08
+
+### Fixed
+- Fix a bug when option `:durable` was ignored when declaring an exchange (a8b59b5)
+
+## [0.13.0] - 2018-06-07
+
+### Changed
+- Freddy actors now communicate with broker through adapters layer
+
+### Added
+- Real AMQP adapter (#15)
+- Sandbox adapter (#16)
+
+## [0.12.1] - 2018-06-04
+
+### Changed
+- Improved documentation (#13)
+- Allow specifying pre-request timeout in `Freddy.RPC.Client` (#14)
+
+## [0.12.0] - 2018-06-01
+
+### Added
+- New callback `decode_message/3` to `Freddy.Consumer` behaviour
+- New callback `encode_message/4` to `Freddy.Publisher` behaviour
+- New callbacks `encode_request/2` and `decode_response/4` to `Freddy.RPC.Client` behaviour
+- New configuration option `:consumer` to `Freddy.Consumer`
+- `{:noreply, state, timeout}` as a possible return value of `Freddy.RPC.Client.handle_ready/2` callback
+- `{:noreply, state, timeout}` as a possible return value of `Freddy.Consumer.handle_ready/2` callback
+- `Freddy.Connection` as a replacement for `Freddy.Conn` module
+
+### Changed
+- Callback `handle_connected/1` in `Freddy.Consumer`, `Freddy.Publisher` and `Freddy.RPC.Client` now accepts
+  two arguments - a connection meta-information and an internal state
+
+### Removed
+- Callback `Freddy.Consumer.handle_error/4` callback is removed
+- Built-in logging from `Freddy.RPC.Client`. Users who need logging, need to implement it themselves in `on_response`,
+  `on_timeout` and `on_return` callbacks
+- Support for different adapters in `Freddy.Connection`
+- Support for custom reconnection backoff intervals in `Freddy.Connection`
+- `hare` dependency
+
+### Fixed
+- Fix a bug with crashing processes during reconnection
+
+## [0.11.0] - 2018-05-12
+
+### Added
+- New callbacks `handle_connected/1` and `handle_disconnected/2` in `Freddy.Consumer`, `Freddy.Publisher`
+  and `Freddy.RPC.Client` behaviours (#11)
+
+## [0.10.2] - 2018-05-12
+
+### Fixed
+- Make default implementation of `Freddy.Consumer.handle_call/3` callback overridable (#10)
+
+### Other
+- Code is formatted with Elixir formatter
+
+## [0.10.1] - 2017-08-29
+
+### Changed
+- Project dependencies are relaxed (#9)
+
+## [0.10.0] - 2017-07-07
+
+### Added
+- `on_return/2` and `on_timeout/2` callbacks to `Freddy.RPC.Client` (#8)
+
+### Changed
+- `Freddy.RPC.Client.before_request/3` now accepts two arguments - a request structure and an internal state (#8)
+- `Freddy.RPC.Client.on_response/3` now accepts request structure as a second argument
+- `Freddy.RPC.Client` isn't bound to fixed routing key anymore (#8)
+
+[0.14.0]: https://github.com/salemove/ex_freddy/compare/v0.13.1...master
+[0.13.1]: https://github.com/salemove/ex_freddy/compare/v0.13.0...v0.13.1
+[0.13.0]: https://github.com/salemove/ex_freddy/compare/v0.12.1...v0.13.0
+[0.12.1]: https://github.com/salemove/ex_freddy/compare/v0.12.0...v0.12.1
+[0.12.0]: https://github.com/salemove/ex_freddy/compare/v0.11.0...v0.12.0
+[0.11.0]: https://github.com/salemove/ex_freddy/compare/v0.10.2...v0.11.0
+[0.10.2]: https://github.com/salemove/ex_freddy/compare/v0.10.1...v0.10.2
+[0.10.1]: https://github.com/salemove/ex_freddy/compare/v0.10.0...v0.10.1
+[0.10.0]: https://github.com/salemove/ex_freddy/compare/v0.9.2...v0.10.0

--- a/lib/freddy/notifications/broadcaster.ex
+++ b/lib/freddy/notifications/broadcaster.ex
@@ -1,14 +1,16 @@
 defmodule Freddy.Notifications.Broadcaster do
-  @moduledoc """
-  `Freddy.Publisher` special case.
+  @moduledoc false
 
-  This module allows to publish messages to `"freddy-topic"` exchange.
+  defmacro __using__(opts \\ []) do
+    warn? = Keyword.get(opts, :warn, true)
 
-  See documentation for `Freddy.Publisher`.
-  """
-
-  defmacro __using__(_opts \\ []) do
     quote location: :keep do
+      if unquote(warn?) do
+        IO.warn(
+          "#{unquote(__MODULE__)} will be removed in Freddy 1.0, use Freddy.Publisher instead"
+        )
+      end
+
       use Freddy.Publisher
 
       defdelegate broadcast(broadcaster, routing_key, payload, opts \\ []),

--- a/lib/freddy/notifications/listener.ex
+++ b/lib/freddy/notifications/listener.ex
@@ -1,29 +1,14 @@
 defmodule Freddy.Notifications.Listener do
-  @moduledoc """
-  `Freddy.Consumer` special case. Listens for notifications from `"freddy-topic"` exchange.
+  @moduledoc false
 
-  Like in `Freddy.Consumer`, you have to specify queue and routing keys to bind to.
+  defmacro __using__(opts \\ []) do
+    warn? = Keyword.get(opts, :warn, true)
 
-  ## Example
-
-      defmodule Notifications.Listener do
-        use Freddy.Notifications.Listener
-
-        @config [
-          queue: [name: "myapp-notifications", opts: [auto_delete: true]],
-          routing_keys: ["broadcast.*"]
-        ]
-
-        def start_link(conn, initial) do
-          Freddy.Notifications.Listener.start_link(__MODULE__, conn, @config, initial)
-        end
+    quote location: :keep do
+      if unquote(warn?) do
+        IO.warn("#{unquote(__MODULE__)} will be removed in Freddy 1.0, use Freddy.Consumer instead")
       end
 
-  See also documentation for `Freddy.Consumer`
-  """
-
-  defmacro __using__(_opts \\ []) do
-    quote location: :keep do
       use Freddy.Consumer
     end
   end

--- a/test/freddy/integration/notifications/broadcaster_test.exs
+++ b/test/freddy/integration/notifications/broadcaster_test.exs
@@ -2,7 +2,7 @@ defmodule Freddy.Integration.Notifications.BroadcasterTest do
   use Freddy.IntegrationCase
 
   defmodule TestBroadcaster do
-    use Freddy.Notifications.Broadcaster
+    use Freddy.Notifications.Broadcaster, warn: false
 
     def start_link(conn) do
       Freddy.Notifications.Broadcaster.start_link(__MODULE__, conn, nil)

--- a/test/freddy/integration/notifications/listener_test.exs
+++ b/test/freddy/integration/notifications/listener_test.exs
@@ -2,7 +2,7 @@ defmodule Freddy.Integration.Notifications.ListenerTest do
   use Freddy.IntegrationCase
 
   defmodule TestBroadcaster do
-    use Freddy.Notifications.Broadcaster
+    use Freddy.Notifications.Broadcaster, warn: false
 
     def start_link(conn) do
       Freddy.Notifications.Broadcaster.start_link(__MODULE__, conn, nil)
@@ -10,7 +10,7 @@ defmodule Freddy.Integration.Notifications.ListenerTest do
   end
 
   defmodule TestListener do
-    use Freddy.Notifications.Listener
+    use Freddy.Notifications.Listener, warn: false
 
     @config [
       queue: [opts: [auto_delete: true]],


### PR DESCRIPTION
- Deprecate `Freddy.Notifications.Listener` and `Freddy.Notifications.Broadcaster`
- Fix CircleCI builds (caches were shared between different Elixir and Erlang versions)
- Add changelog