### PR TITLE
Add delete_queue for adapters

### DIFF
--- a/lib/freddy/adapter.ex
+++ b/lib/freddy/adapter.ex
@@ -85,6 +85,11 @@ defmodule Freddy.Adapter do
   """
   @callback bind_queue(channel, queue_name, exchange_name, options) :: :ok | {:error, error}
 
+  @doc """
+  Deletes the given queue
+  """
+  @callback delete_queue(channel, queue_name, options) :: :ok | {:error, error}
+
   ## Basic
 
   @doc """

--- a/lib/freddy/adapter.ex
+++ b/lib/freddy/adapter.ex
@@ -88,7 +88,7 @@ defmodule Freddy.Adapter do
   @doc """
   Deletes the given queue
   """
-  @callback delete_queue(channel, queue_name, options) :: :ok | {:error, error}
+  @callback delete_queue(channel, queue_name, options) :: {:ok, meta} | {:error, error}
 
   ## Basic
 

--- a/lib/freddy/adapter/amqp.ex
+++ b/lib/freddy/adapter/amqp.ex
@@ -46,6 +46,9 @@ defmodule Freddy.Adapter.AMQP do
   @impl true
   defdelegate bind_queue(channel, queue, exchange, options), to: Queue, as: :bind
 
+  @impl true
+  defdelegate delete_queue(channel, queue, options), to: Queue, as: :delete
+
   # Basic
 
   @impl true

--- a/lib/freddy/adapter/amqp/core.ex
+++ b/lib/freddy/adapter/amqp/core.ex
@@ -21,6 +21,14 @@ defmodule Freddy.Adapter.AMQP.Core do
             :"queue.bind_ok",
             extract(:"queue.bind_ok", from_lib: "rabbit_common/include/rabbit_framing.hrl")
 
+  defrecord :queue_delete,
+            :"queue.delete",
+            extract(:"queue.delete", from_lib: "rabbit_common/include/rabbit_framing.hrl")
+
+  defrecord :queue_delete_ok,
+            :"queue.delete_ok",
+            extract(:"queue.delete_ok", from_lib: "rabbit_common/include/rabbit_framing.hrl")
+
   defrecord :basic_ack,
             :"basic.ack",
             extract(:"basic.ack", from_lib: "rabbit_common/include/rabbit_framing.hrl")

--- a/lib/freddy/adapter/amqp/queue.ex
+++ b/lib/freddy/adapter/amqp/queue.ex
@@ -37,4 +37,19 @@ defmodule Freddy.Adapter.AMQP.Queue do
       error -> error
     end
   end
+
+  def delete(channel, queue, options) do
+    queue_delete =
+      queue_delete(
+        queue: queue,
+        if_unused: Keyword.get(options, :if_unused, false),
+        if_empty: Keyword.get(options, :if_empty, false),
+        nowait: Keyword.get(options, :no_wait, false)
+      )
+
+    case Channel.call(channel, queue_delete) do
+      queue_delete_ok(message_count: message_count) -> {:ok, %{message_count: message_count}}
+      error -> error
+    end
+  end
 end

--- a/lib/freddy/adapter/sandbox.ex
+++ b/lib/freddy/adapter/sandbox.ex
@@ -119,6 +119,13 @@ defmodule Freddy.Adapter.Sandbox do
   end
 
   @impl true
+  def delete_queue(channel, queue, options) do
+    Channel.register(channel, :delete_queue, [channel, queue, options])
+    # For the sandbox always return 0 messages
+    {:ok, %{message_count: 0}}
+  end
+
+  @impl true
   def publish(channel, exchange, routing_key, payload, opts) do
     register(channel, :publish, [channel, exchange, routing_key, payload, opts])
   end

--- a/test/freddy/adapter/sandbox_test.exs
+++ b/test/freddy/adapter/sandbox_test.exs
@@ -54,11 +54,14 @@ defmodule Freddy.Adapter.SandboxTest do
     consumer = self()
     assert {:ok, tag} = consume(chan, name, consumer, [])
 
+    assert {:ok, meta} = delete_queue(chan, name, [])
+
     assert [
              {:open_channel, [^conn]},
              {:declare_queue, [^chan, "", [durable: true]]},
              {:bind_queue, [^chan, ^name, "topic-exchange", [routing_key: "#"]]},
-             {:consume, [^chan, ^name, ^consumer, ^tag, []]}
+             {:consume, [^chan, ^name, ^consumer, ^tag, []]},
+             {:delete_queue, [^chan, ^name, []]}
            ] = history(conn)
   end
 


### PR DESCRIPTION
I've enjoyed using this project and I love using the sandbox adapter for tests. I have a need for deleting a queue since I am using durable queues. I could definitely use amqp directly, but then no sandbox :cry: 

This adds delete_queue just to the adapters and corresponding tests. It does not change any of the behaviors. An example of how I am calling it from within a consumer is:

```
def handle_cast(
      :my_message,
      %{meta: %{channel: %{adapter: adapter, chan: chan}, queue: %{name: queue_name}}} = state
    ) do
  {:ok, _meta} = adapter.delete_queue(chan, queue_name, [])
  {:noreply, state}
end
```

Thanks!