### PR TITLE
Add unbind_queue to adapters

### DIFF
--- a/lib/freddy/adapter.ex
+++ b/lib/freddy/adapter.ex
@@ -86,6 +86,11 @@ defmodule Freddy.Adapter do
   @callback bind_queue(channel, queue_name, exchange_name, options) :: :ok | {:error, error}
 
   @doc """
+  Unbinds given queue to the exchange
+  """
+  @callback unbind_queue(channel, queue_name, exchange_name, options) :: :ok | {:error, error}
+
+  @doc """
   Deletes the given queue
   """
   @callback delete_queue(channel, queue_name, options) :: {:ok, meta} | {:error, error}

--- a/lib/freddy/adapter/amqp.ex
+++ b/lib/freddy/adapter/amqp.ex
@@ -47,6 +47,9 @@ defmodule Freddy.Adapter.AMQP do
   defdelegate bind_queue(channel, queue, exchange, options), to: Queue, as: :bind
 
   @impl true
+  defdelegate unbind_queue(channel, queue, exchange, options), to: Queue, as: :unbind
+
+  @impl true
   defdelegate delete_queue(channel, queue, options), to: Queue, as: :delete
 
   # Basic

--- a/lib/freddy/adapter/amqp/core.ex
+++ b/lib/freddy/adapter/amqp/core.ex
@@ -21,6 +21,14 @@ defmodule Freddy.Adapter.AMQP.Core do
             :"queue.bind_ok",
             extract(:"queue.bind_ok", from_lib: "rabbit_common/include/rabbit_framing.hrl")
 
+  defrecord :queue_unbind,
+            :"queue.unbind",
+            extract(:"queue.unbind", from_lib: "rabbit_common/include/rabbit_framing.hrl")
+
+  defrecord :queue_unbind_ok,
+            :"queue.unbind_ok",
+            extract(:"queue.unbind_ok", from_lib: "rabbit_common/include/rabbit_framing.hrl")
+
   defrecord :queue_delete,
             :"queue.delete",
             extract(:"queue.delete", from_lib: "rabbit_common/include/rabbit_framing.hrl")

--- a/lib/freddy/adapter/amqp/queue.ex
+++ b/lib/freddy/adapter/amqp/queue.ex
@@ -38,6 +38,21 @@ defmodule Freddy.Adapter.AMQP.Queue do
     end
   end
 
+  def unbind(channel, queue, exchange, options) do
+    queue_unbind =
+      queue_unbind(
+        queue: queue,
+        exchange: exchange,
+        routing_key: Keyword.get(options, :routing_key, ""),
+        arguments: Keyword.get(options, :arguments, []) |> to_type_tuple()
+      )
+
+    case Channel.call(channel, queue_unbind) do
+      queue_unbind_ok() -> :ok
+      error -> error
+    end
+  end
+
   def delete(channel, queue, options) do
     queue_delete =
       queue_delete(

--- a/lib/freddy/adapter/sandbox.ex
+++ b/lib/freddy/adapter/sandbox.ex
@@ -119,6 +119,12 @@ defmodule Freddy.Adapter.Sandbox do
   end
 
   @impl true
+  def unbind_queue(channel, queue, exchange, options) do
+    Channel.register(channel, :unbind_queue, [channel, queue, exchange, options])
+    :ok
+  end
+
+  @impl true
   def delete_queue(channel, queue, options) do
     Channel.register(channel, :delete_queue, [channel, queue, options])
     # For the sandbox always return 0 messages

--- a/test/freddy/adapter/sandbox_test.exs
+++ b/test/freddy/adapter/sandbox_test.exs
@@ -54,6 +54,8 @@ defmodule Freddy.Adapter.SandboxTest do
     consumer = self()
     assert {:ok, tag} = consume(chan, name, consumer, [])
 
+    assert :ok = unbind_queue(chan, name, "topic-exchange", routing_key: "#")
+
     assert {:ok, meta} = delete_queue(chan, name, [])
 
     assert [
@@ -61,6 +63,7 @@ defmodule Freddy.Adapter.SandboxTest do
              {:declare_queue, [^chan, "", [durable: true]]},
              {:bind_queue, [^chan, ^name, "topic-exchange", [routing_key: "#"]]},
              {:consume, [^chan, ^name, ^consumer, ^tag, []]},
+             {:unbind_queue, [^chan, ^name, "topic-exchange", [routing_key: "#"]]},
              {:delete_queue, [^chan, ^name, []]}
            ] = history(conn)
   end


### PR DESCRIPTION
Adds `unbind_queue/4` to the amqp and sandbox adapters.

I modified a test for the sandbox adapter to test unbind_queue, but I didn't know how best to test the amqp adapter. From what I can tell rabbitmq doesn't offer a way to view the bindings of a queue in the protocol. It only appears to be in the management ui/api. I did test it with a full integration and it removed the binding in rabbitmq.

Thanks!

