### PR TITLE
Set span status to error on exception

### DIFF
--- a/lib/freddy/tracer.ex
+++ b/lib/freddy/tracer.ex
@@ -52,7 +52,16 @@ defmodule Freddy.Tracer do
       links: [link],
       kind: :consumer
     } do
-      block.()
+      try do
+        block.()
+      rescue
+        exception ->
+          ctx = OpenTelemetry.Tracer.current_span_ctx()
+          OpenTelemetry.Span.record_exception(ctx, exception, __STACKTRACE__, [])
+          OpenTelemetry.Tracer.set_status(OpenTelemetry.status(:error, ""))
+
+          reraise(exception, __STACKTRACE__)
+      end
     end
   end
 


### PR DESCRIPTION
Tracing is much more useful if user can find problematic traces. Here,
in case there's an uncaught exception in the consumer, lets mark the
span status to error and record error information.