### PR TITLE
Fix extracting headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [0.16.0] (In progress)
+## [0.17.0] (In progress)
+
+- Add OpenTelemetry support
+
+## [0.16.0] (2020-12-18)
+
+- Catch open_channel messages (#36)
 
 ## [0.15.2] (2019-07-12)
 

--- a/lib/freddy/tracer.ex
+++ b/lib/freddy/tracer.ex
@@ -30,7 +30,7 @@ defmodule Freddy.Tracer do
   end
 
   def with_process_span(meta, exchange, mod, block) do
-    headers = normalize_headers(Map.get(meta, :headers, %{}))
+    headers = normalize_headers(Map.get(meta, :headers, []))
     :otel_propagator.text_map_extract(headers)
 
     routing_key = Map.get(meta, :routing_key)
@@ -65,8 +65,11 @@ defmodule Freddy.Tracer do
     end
   end
 
-  # amqp returns headers in {key, type, value} format. Convert these into just
-  # {key, value}.
+  # amqp uses `:undefined` if no headers are present
+  defp normalize_headers(:undefined), do: []
+
+  # amqp returns headers in [{key, type, value}, ...] format. Convert these
+  # into just [{key, value}].
   defp normalize_headers(headers) do
     Enum.map(headers, fn {key, _type, value} -> {key, value} end)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Freddy.Mixfile do
   def project do
     [
       app: :freddy,
-      version: "0.17.0",
+      version: "0.17.0-rc.3",
       elixir: "~> 1.6",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,


### PR DESCRIPTION
Two changes:
* Headers are a keyword list, so default to `[]`. This however didn't
 actually seem to be a problem because of the point below.
* If headers are not present then the value is `:undefined` instead of
 an empty list or a missing value. This commit handles this case.