### PR TITLE
Fix creating a trace when there's no parent

### DIFF
--- a/lib/freddy/core/exchange.ex
+++ b/lib/freddy/core/exchange.ex
@@ -80,8 +80,13 @@ defmodule Freddy.Core.Exchange do
           :ok | {:error, atom}
   def publish(%__MODULE__{} = exchange, %{adapter: adapter, chan: chan}, message, routing_key, opts) do
     Freddy.Tracer.with_send_span(exchange, routing_key, fn tracing_headers ->
-      new_headers = Keyword.merge(opts[:headers] || [], tracing_headers)
-      opts = Keyword.put(opts, :headers, new_headers)
+      opts =
+        if opts[:disable_trace_propagation] do
+          opts
+        else
+          new_headers = Keyword.merge(opts[:headers] || [], tracing_headers)
+          Keyword.put(opts, :headers, new_headers)
+        end
 
       adapter.publish(chan, exchange.name, routing_key, message, opts)
     end)

--- a/lib/freddy/tracer.ex
+++ b/lib/freddy/tracer.ex
@@ -36,7 +36,7 @@ defmodule Freddy.Tracer do
     routing_key = Map.get(meta, :routing_key)
 
     parent = OpenTelemetry.Tracer.current_span_ctx()
-    link = OpenTelemetry.link(parent)
+    links = if parent == :undefined, do: [], else: [OpenTelemetry.link(parent)]
 
     destination_kind = if exchange.type == :direct, do: "queue", else: "topic"
 
@@ -49,7 +49,7 @@ defmodule Freddy.Tracer do
         "messaging.operation": "process",
         "messaging.freddy.worker": to_string(mod)
       ],
-      links: [link],
+      links: links,
       kind: :consumer
     } do
       try do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Freddy.Mixfile do
   def project do
     [
       app: :freddy,
-      version: "0.17.0-rc.3",
+      version: "0.17.0-rc.4",
       elixir: "~> 1.6",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,


### PR DESCRIPTION
Previously when the consumer received a message which didn't include 
tracing information an error occured (in the opentelemetry exporter 
process) because the current_span_ctx returned `:undefined`. Now this case
is handled and tested.