### PR TITLE
Migrate Docker images from Docker Hub to ECR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   elixir:
     services:
       rabbitmq:
-        image: rabbitmq:3.8-alpine
+        image: public.ecr.aws/docker/library/rabbitmq:3.8-alpine
         ports:
           - "5672:5672"
     name: OTP ${{matrix.pair.otp}} / Elixir ${{matrix.pair.elixir}}


### PR DESCRIPTION
Docker Hub is lowering rate limits significantly, and pulling images from Docker Hub has become a risk. Migrate all of the images that still pull images from docker hub to either private or public ECR.

AUTO-1796